### PR TITLE
Update SDK version, handle missing dataExplorerLink

### DIFF
--- a/sync-todo/v2/client/swiftui/App.xcodeproj/project.pbxproj
+++ b/sync-todo/v2/client/swiftui/App.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.35.0;
+				minimumVersion = 10.42.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/sync-todo/v2/client/swiftui/App/App.swift
+++ b/sync-todo/v2/client/swiftui/App/App.swift
@@ -15,9 +15,6 @@ let app = App(id: theAppConfig.appId, configuration: AppConfiguration(baseURL: t
 struct realmSwiftUIApp: SwiftUI.App {
     @StateObject var errorHandler = ErrorHandler(app: app)
 
-    init(){
-        print("To see the changes in Atlas, open this link: " + theAppConfig.atlasUrl)
-    }
     var body: some Scene {
         WindowGroup {
             ContentView(app: app)
@@ -26,6 +23,11 @@ struct realmSwiftUIApp: SwiftUI.App {
                     Button("OK", role: .cancel) { errorHandler.error = nil }
                 } message: {
                     Text(errorHandler.error?.localizedDescription ?? "")
+                }
+                .onAppear {
+                    if let atlasUrl = atlasUrl {
+                        print("To view your data in Atlas, go to this link: " + atlasUrl)
+                    }
                 }
         }
     }

--- a/sync-todo/v2/client/swiftui/App/AppConfig.swift
+++ b/sync-todo/v2/client/swiftui/App/AppConfig.swift
@@ -6,7 +6,7 @@ import RealmSwift
 struct AppConfig {
     var appId: String
     var baseUrl: String
-    var atlasUrl: String
+    var atlasUrl: String?
 }
 
 /// Read the atlasConfig.plist file and store the app ID and baseUrl to use elsewhere.
@@ -21,6 +21,15 @@ func loadAppConfig() -> AppConfig {
     let atlasConfigPropertyList = try! PropertyListSerialization.propertyList(from: data, format: nil) as! [String: Any]
     let appId = atlasConfigPropertyList["appId"]! as! String
     let baseUrl = atlasConfigPropertyList["baseUrl"]! as! String
-    let atlasUrl = atlasConfigPropertyList["dataExplorerLink"]! as! String
-    return AppConfig(appId: appId, baseUrl: baseUrl, atlasUrl: atlasUrl)
+    
+    // If you're getting this app code by cloning the repository at
+    // https://github.com/mongodb/template-app-swiftui-todo
+    // it does not contain the data explorer link. Download the
+    // app template from the Atlas UI to view a link to your data.
+    let atlasUrl = atlasConfigPropertyList["dataExplorerLink"]
+    if let atlasUrl = atlasUrl {
+        return AppConfig(appId: appId, baseUrl: baseUrl, atlasUrl: atlasUrl as? String)
+    } else {
+        return AppConfig(appId: appId, baseUrl: baseUrl, atlasUrl: nil)
+    }
 }

--- a/sync-todo/v2/client/swiftui/App/Views/CreateItemView.swift
+++ b/sync-todo/v2/client/swiftui/App/Views/CreateItemView.swift
@@ -41,7 +41,9 @@ struct CreateItemView: View {
                     // return to the ItemsView.
                     isInCreateItemView = false
                     
-                    print("To see the changes in Atlas, open this link: " + theAppConfig.atlasUrl)
+                    if let atlasUrl = atlasUrl {
+                        print("To see your new item in Atlas, go to this link: " + atlasUrl)
+                    }
                     
                 }) {
                     HStack {

--- a/sync-todo/v2/client/swiftui/App/Views/ItemList.swift
+++ b/sync-todo/v2/client/swiftui/App/Views/ItemList.swift
@@ -21,10 +21,12 @@ struct ItemList: View {
             Text("Log in or create a different account on another device or simulator to see your list sync in real time")
                 .frame(maxWidth: 300, alignment: .center)
             Spacer()
-            Link("Tap here to view your changes in Atlas.", destination: URL(string: theAppConfig.atlasUrl)!)
-                .font(.body)
-                .frame(maxWidth: 300, alignment: .center)
-                .foregroundColor(Color.blue)
+            if let atlasUrl = atlasUrl {
+                Link("Tap here to view your data in Atlas.", destination: URL(string: atlasUrl)!)
+                    .font(.body)
+                    .frame(maxWidth: 300, alignment: .center)
+                    .foregroundColor(Color.blue)
+            }
         }
         .navigationBarTitle("Items", displayMode: .inline)
     }


### PR DESCRIPTION
Your updates assume that the person has downloaded this template from the Atlas UI, but they could also be cloning it from the template app artifact repositories. In that case, it won't have the `dataExplorerLink` and force unwrapping it causes the app to crash. This handles a missing `dataExplorerLink` gracefully, and it also updates the Realm Swift SDK version since we're touching the app anyway. (And uses the more SwiftUI-ish `onAppear` to print the line to the console vs. the `init` in the view body.)